### PR TITLE
Axios Dependency Server-Side Request Forgery Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,9 +59,9 @@
       "dev": true
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
         "follow-redirects": "1.4.1",
         "is-buffer": "1.1.6"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "tslint": "^5.9.1"
   },
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.21.1",
     "iconv-lite": "^0.4.19",
     "moment": "^2.21.0",
     "typescript": "^2.7.2"


### PR DESCRIPTION
Updates the Axios dependency to the latest release version to resolve a known server-side request forgery vulnerability. See: https://www.npmjs.com/advisories/1594

This will fix issue #1.